### PR TITLE
Change Travis build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ deploy:
   app: vast-stream-78160
   on:
     repo: erickzhao/invite-contributors
-scripts:
+script:
 - npm run test
-- npm run code-coverage
+- npm run report-coverage

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://api.travis-ci.org/erickzhao/invite-contributors.svg?branch=master)](https://travis-ci.org/erickzhao/invite-contributors)
 
+[![codecov](https://codecov.io/gh/erickzhao/invite-contributors/branch/master/graph/badge.svg)](https://codecov.io/gh/erickzhao/invite-contributors)
+
 **invite-contributors** is a GitHub App built with [probot](https://github.com/probot/probot) that automatically invites new contributors to your repository's organization once they get a Pull Request merged.
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "repository": "https://github.com/erickzhao/invite-contributors.git",
   "scripts": {
     "start": "probot run ./index.js",
-    "test": "mocha && standard",
-    "report-coverage": "nyc mocha && codecov"
+    "test": "nyc mocha && standard",
+    "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
   },
   "dependencies": {
     "probot": "^3.0.0"


### PR DESCRIPTION
Tested that TravisCI and Codecov integration worked in `npm-test` branch. Everything seems to go smoothly.

Now `npm test` also gives code coverage stats from nyc, and any successful TravisCI builds will push code coverage data from nyc to Codecov.